### PR TITLE
Allow src/dest tuples (with meta-info to control replace/append path)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 /example
+.idea

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # lein-zip
 
-minimal leiningen plugin that zips files
+Leiningen plugin that zips files
 
 ## Example Usage
 
-[![Clojars Project](http://clojars.org/lein-zip/latest-version.svg)](http://clojars.org/lein-zip)
+[![Clojars Project](http://clojars.org/gorillalabs/lein-zip/latest-version.svg)](http://clojars.org/gorillalabs/lein-zip)
 
 Add the following to project.clj
 
 ```clojure
-:zip ["file1" "resources/file2" "target/production.jar" "dir1"]
+:zip [^:replace-path ["target/uber.jar" "lib/"]
+      "resources/file2"
+      "dir1"
+      ["dir2/" "dir3/"]
+      ^:replace-path["dir2/" "dir4/"]]
 ```
+
+You can give a vector of files or source/destination tuples. The files will be added to the
+zip with their path. Directories will include all files (but not recursively). If given a
+src/dest-tuple, the dest will be set or prepended to the path dependent on the :replace-with metadata. If replace-with is set, the original path will be replaced with the new path, else the destination-path will prepend the original path.
 
 Then
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,21 @@
-(defproject lein-zip "0.1.1"
+(defproject gorillalabs/lein-zip "0.1.1"
   :description "Zips files"
-  :url "https://github.com/mrmcc3/lein-zip"
+  :url "https://github.com/gorillalabs/lein-zip"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :repositories [["clojars" {:sign-releases false}]]
-  :eval-in-leiningen true)
+  :eval-in-leiningen true
+  :plugins [[com.roomkey/lein-v "7.0.0"]]
+
+  :middleware [leiningen.v/version-from-scm
+               leiningen.v/dependency-version-from-scm
+               leiningen.v/add-workspace-data]
+  :scm {:name "git"
+        :url  "https://github.com/gorillalabs/lein-zip"}
+
+  ;; make sure you have your ~/.lein/credentials.clj.gpg setup correctly
+
+  :deploy-repositories [["releases" :clojars]]
+  :release-tasks [["vcs" "assert-committed"]
+                  ["v" "update"]
+                  ["deploy" "clojars"]
+                  ["vcs" "push"]])

--- a/src/leiningen/zip.clj
+++ b/src/leiningen/zip.clj
@@ -1,21 +1,66 @@
 (ns leiningen.zip
   (:require [clojure.java.io :as io]
-            [leiningen.core.main :refer [info]])
-  (:import [java.io FileOutputStream]
+            [leiningen.core.main :refer [info warn]]
+            [leiningen.core.utils :as utils]
+            [clojure.string :as s])
+  (:import [java.io File]
            [java.util.zip ZipOutputStream ZipEntry]))
 
+;; from Meikel Brandmeyer,
+;; https://stackoverflow.com/questions/17965763/zip-a-file-in-clojure
+(defmacro ^:private with-entry
+  [zip entry-name & body]
+  `(let [^ZipOutputStream zip# ~zip]
+     (.putNextEntry zip# (ZipEntry. ~entry-name))
+     ~@body
+     (flush)
+     (.closeEntry zip#)))
+
+(defn- output-filename [n v]
+  (str n "-" v ".zip"))
+
+(defn out-path
+  "Given a path p and a file, returns the entry path inside the ZIP archive.
+  Path might be a filename (which will be identical to the filename for f).
+  Things become more interesting if p is a tuple (i.e. a two-value vector): Here,
+  the first value is the path to the file, but the second value is the destination
+  inside the ZIP archive.
+
+  If that second value (destintion) denotes a file, i.e. destination does not
+  end with an /, that name will be the entry path, i.e. the file will be copied
+  into the ZIP starting at top level.
+
+  If the seconde item is a directory, behaviour is defined by the metadata to
+  the tuple: If no meta data is given or :replace-path is false, the destination
+  is just prepended to the filepath, so nesting is deeper. If :replace-path is true,
+  the file is inserted directly under the destination with no further folders created."
+  [p ^File f]
+  (if-not (coll? p)
+    (.getPath f)
+    (let [entry (second p)]
+      (if (s/ends-with? entry "/")
+        (if (:replace-path (meta p))
+          (str entry (.getName f))
+          (str entry (.getPath f)))
+        entry))))
+
 (defn zip
-  "Zips files from :zip in project.clj
-  to target/project-version.zip"
-  [{v :version n :name paths :zip}]
-  (with-open [out (-> (str "target/" n "-" v ".zip")
-                      (FileOutputStream.)
-                      (ZipOutputStream.))]
-    (doseq [p paths
-            f (file-seq (io/file p))]
-        (when-not (.isDirectory f)
-          (with-open [in (io/input-stream f)]
-            (.putNextEntry out (ZipEntry. (.getPath f)))
-            (io/copy in out)
-            (.closeEntry out)
-            (info "zipped file" (.getPath f)))))))
+  "Zips files from :zip in project.clj to target/project-version.zip"
+  [{v :version n :name target-path :target-path paths :zip}]
+  (let [target (doto (io/file target-path) utils/mkdirs)
+        target-zip-file (io/file target (output-filename n v))]
+    (info "About to create " (.getCanonicalPath target-zip-file))
+    (with-open [intermediate-output-stream (io/output-stream target-zip-file)
+                out (ZipOutputStream. intermediate-output-stream)]
+      (doseq [p paths]
+        (doseq [^File f (file-seq (io/file (if (coll? p) (first p) p)))]
+          (if-not (.exists f)
+            (warn (.getPath f) "does not exist")
+            (if-not (.canRead f)
+              (warn "Cannot read" (.getPath f))
+              (when-not (.isDirectory f)
+                (with-open [in (io/input-stream f)]
+                  (let [entry (out-path p f)]
+                    (with-entry out entry
+                                (io/copy in out))
+                    (info "zipped file" (.getPath f) "to" entry)))))))))))

--- a/test/leiningen/zip.clj
+++ b/test/leiningen/zip.clj
@@ -1,0 +1,32 @@
+(ns leiningen.zip
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
+            [leiningen.zip :as zip]))
+
+#_(def $project {:version     "1.2.3"
+               :name        "somename"
+               :target-path "target/"
+               :zip         ["test/leiningen/zip.clj"
+                             ["test/leiningen/zip.clj" "dingdong.clj"]
+                             ["test/leiningen/zip.clj" "dingdong/"]
+                             ^{:replace-path false} ["test/leiningen/zip.clj" "razonk/"]
+                             ^:replace-path ["src/leiningen/zip.clj" "razonk/"]
+                             ^:replace-path ["src/leiningen/zip.clj" "razonk.clj"]]})
+
+(deftest test-out-path
+  (let [f (io/file "test/leiningen/zip.clj")]
+    (is (= "test/leiningen/zip.clj"
+           (zip/out-path "test/leiningen/zip.clj"
+                     f)))
+    (is (= "dingdong.clj"
+           (zip/out-path ["test/leiningen/zip.clj" "dingdong.clj"]
+                     f)))
+    (is (= "dingdong/test/leiningen/zip.clj"
+           (zip/out-path ["test/leiningen/zip.clj" "dingdong/"]
+                     f)))
+    (is (= "dingdong/test/leiningen/zip.clj"
+           (zip/out-path ^{:replace-path false} ["test/leiningen/zip.clj" "dingdong/"]
+                     f)))
+    (is (= "dingdong/zip.clj"
+           (zip/out-path ^:replace-path ["src/leiningen/zip.clj" "dingdong/"]
+                     f)))))


### PR DESCRIPTION
Hi,

I needed to update lein zip to allow setting destinations, so the source files do not need to be at the location in the git repo I want them to be at in the ZIP.

Feel free to take or leave, as I forked and pushed my version to clojars in order to use it right away. However, it might be something helpful for others, too.

Happy hacking

Chris